### PR TITLE
fix: read input from user in shell script

### DIFF
--- a/CSPC24 - ULP/03_shell_scripts/05_search_list.sh
+++ b/CSPC24 - ULP/03_shell_scripts/05_search_list.sh
@@ -1,11 +1,11 @@
 # Write a shell Script program to search whether the element is present is in the list or not.
 
 #!/bin/bash
-value = $1
 echo "Enter a value to check if it exists in the list --> "
+read -r value
 # read value
-arr = (10 3 2 34 543 5)
-if [[ " ${arr[*]} " =~ " ${value} " ]]; then
+arr=(10 3 2 34 543 5)
+if [[ "${arr[*]}" =~ $value ]]; then
 	echo "Element exists."
 
 else


### PR DESCRIPTION
The present code is somewhat confusing to run, and had some minor bash quirks
that `bash-language-server` caught. This small PR just fixes those minor quirks
and also reads the input from the user using `read` instead of command line arguments.